### PR TITLE
Possibility to set MultiUpload component in indeterminate mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.wcs.wcslib</groupId>
     <artifactId>wcslib-vaadin-widget-multifileupload</artifactId>
     <packaging>jar</packaging>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.8.8</version>
     <name>MultiFileUpload</name>
     
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.wcs.wcslib</groupId>
     <artifactId>wcslib-vaadin-widget-multifileupload</artifactId>
     <packaging>jar</packaging>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.8.1-SNAPSHOT</version>
     <name>MultiFileUpload</name>
     
     <scm>

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/WidgetTestApplication.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/WidgetTestApplication.java
@@ -19,20 +19,12 @@ import com.vaadin.data.Property;
 import com.vaadin.server.StreamVariable;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.shared.communication.PushMode;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.CheckBox;
-import com.vaadin.ui.ComboBox;
-import com.vaadin.ui.FormLayout;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.Notification;
-import com.vaadin.ui.OptionGroup;
-import com.vaadin.ui.Slider;
-import com.vaadin.ui.UI;
-import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.*;
 import com.wcs.wcslib.vaadin.widget.multifileupload.ui.MultiFileUpload;
 import com.wcs.wcslib.vaadin.widget.multifileupload.ui.UploadFinishedHandler;
 import com.wcs.wcslib.vaadin.widget.multifileupload.ui.UploadStatePanel;
 import com.wcs.wcslib.vaadin.widget.multifileupload.ui.UploadStateWindow;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -80,8 +72,9 @@ public class WidgetTestApplication extends UI {
         createUploadFinishedHandler();
         uploads.clear();
 
-        addSlowUploadExample("Single upload", false);
-        addSlowUploadExample("Multiple upload", true);
+        addSlowUploadExample("Multiple with indeterminate progress", true, true);
+        addSlowUploadExample("Single upload", false, false);
+        addSlowUploadExample("Multiple upload", true, false);
 
         addUploadAttachedCheckBoxes();
 
@@ -94,10 +87,12 @@ public class WidgetTestApplication extends UI {
     private void addLabels() {
         root.addComponent(new Label("These upload fields use the same window for displaying an upload queue and a "
                 + "progress indicator for each field."));
-        root.addComponent(new Label("You can select multiple files to upload if your browser support it (Firefox, Chrome)."));
+        root.addComponent(new Label(
+                "You can select multiple files to upload if your browser support it (Firefox, Chrome)."));
         root.addComponent(new Label("You can cancel the current upload or remove files from the upload queue."));
         root.addComponent(new Label("You can force the MultiFileUpload to behave like the stock Upload component."));
-        root.addComponent(new Label("In browsers which not support HTML5, this field behaves like the stock Upload component with the shared window functionality."));
+        root.addComponent(new Label(
+                "In browsers which not support HTML5, this field behaves like the stock Upload component with the shared window functionality."));
         root.addComponent(new Label("You can slow down and speed up the upload speed. This is for the demo only."));
     }
 
@@ -105,12 +100,12 @@ public class WidgetTestApplication extends UI {
         uploadFinishedHandler = new UploadFinishedHandler() {
             @Override
             public void handleFile(InputStream stream, String fileName, String mimeType, long length) {
-                Notification.show(fileName + " upsloaded.");
+                Notification.show(fileName + " uploaded.");
             }
         };
     }
 
-    private void addSlowUploadExample(String caption, boolean multiple) {
+    private void addSlowUploadExample(String caption, boolean multiple, boolean indeterminate) {
         SlowUpload slowUpload = new SlowUpload(uploadFinishedHandler, uploadStateWindow, multiple);
         int maxFileSize = 5242880; //5 MB
         slowUpload.setMaxFileSize(maxFileSize);
@@ -119,6 +114,7 @@ public class WidgetTestApplication extends UI {
         slowUpload.setCaption(caption);
         slowUpload.setPanelCaption(caption);
         slowUpload.getSmartUpload().setUploadButtonCaptions("Upload File", "Upload Files");
+        slowUpload.setIndeterminate(indeterminate);
         form.addComponent(slowUpload, 0);
         uploads.add(slowUpload);
     }

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/AllFilesUploadedHandler.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/AllFilesUploadedHandler.java
@@ -1,0 +1,6 @@
+package com.wcs.wcslib.vaadin.widget.multifileupload.ui;
+
+public interface AllFilesUploadedHandler {
+
+    void uploaded();
+}

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/MultiFileUpload.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/MultiFileUpload.java
@@ -19,10 +19,11 @@ import com.vaadin.server.Resource;
 import com.vaadin.ui.CustomComponent;
 import com.vaadin.ui.Notification;
 import com.wcs.wcslib.vaadin.widget.multifileupload.component.SmartMultiUpload;
+
 import java.util.List;
 
 /**
- *
+ * 
  * @author gergo
  */
 public class MultiFileUpload extends CustomComponent {
@@ -98,17 +99,19 @@ public class MultiFileUpload extends CustomComponent {
     }
 
     /**
-     *
-     * @param pattern Pattern of the error message, which occurs when a user uploaded too big file. ({0} maxFileSize,
-     * {1} fileSize, {2} fileName)
+     * 
+     * @param pattern
+     *            Pattern of the error message, which occurs when a user uploaded too big file. ({0} maxFileSize, {1}
+     *            fileSize, {2} fileName)
      */
     public void setSizeErrorMsgPattern(String pattern) {
         smartUpload.setSizeErrorMsgPattern(pattern);
     }
 
     /**
-     *
-     * @param maxVisibleRows The number of rows which after the upload queue table renders a scrollbar.
+     * 
+     * @param maxVisibleRows
+     *            The number of rows which after the upload queue table renders a scrollbar.
      */
     public void setMaxVisibleRows(int maxVisibleRows) {
         uploadStatePanel.getTable().setMaxVisibleRows(maxVisibleRows);
@@ -118,9 +121,9 @@ public class MultiFileUpload extends CustomComponent {
      * Sets mime types that browser should let users upload. This check is done by the client side and not supported by
      * all browsers. Some browser us the accept filter just as a initial filter for their file chooser dialog. Note that
      * using this method does not invalidate need for server side checks.
-     *
+     * 
      * See https://developer.mozilla.org/en-US/docs/HTML/Element/Input
-     *
+     * 
      * @param accept
      */
     public void setAcceptFilter(String accept) {
@@ -129,19 +132,21 @@ public class MultiFileUpload extends CustomComponent {
 
     /**
      * Sets valid mime types.
-     *
+     * 
      * See http://reference.sitepoint.com/html/mime-types-full
-     *
-     * @param mimeTypes Mime types should be accepted.
+     * 
+     * @param mimeTypes
+     *            Mime types should be accepted.
      */
     public void setAcceptedMimeTypes(List<String> mimeTypes) {
         smartUpload.setAcceptedMimeTypes(mimeTypes);
     }
 
     /**
-     *
-     * @param pattern Pattern of the error message, which occurs when a user uploaded a file that is not match to the
-     * given mime types. ({0} fileName)
+     * 
+     * @param pattern
+     *            Pattern of the error message, which occurs when a user uploaded a file that is not match to the given
+     *            mime types. ({0} fileName)
      */
     public void setMimeTypeErrorMsgPattern(String pattern) {
         smartUpload.setMimeTypeErrorMsgPattern(pattern);
@@ -174,5 +179,14 @@ public class MultiFileUpload extends CustomComponent {
 
         super.detach();
         uploadStatePanel.getWindow().removePanel(uploadStatePanel);
+    }
+
+    public void setIndeterminate(final boolean indeterminate) {
+        this.getUploadStatePanel().getCurrentUploadingLayout().setIndeterminate(indeterminate);
+        this.setOverallProgressVisible(!indeterminate);
+    }
+
+    public void setOverallProgressVisible(final boolean overallProgressVisible) {
+        this.getUploadStatePanel().getWindow().setOverallProgressVisible(overallProgressVisible);
     }
 }

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/MultiFileUpload.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/MultiFileUpload.java
@@ -37,8 +37,12 @@ public class MultiFileUpload extends CustomComponent {
         initSmartUpload(handler, multiple);
     }
 
-    public MultiFileUpload(UploadFinishedHandler handler, UploadStateWindow uploadStateWindow) {
-        this(handler, uploadStateWindow, true);
+    public MultiFileUpload() {
+        this(null, new UploadStateWindow(), true);
+    }
+
+    public MultiFileUpload(final boolean multiple) {
+        this(null, new UploadStateWindow(), multiple);
     }
 
     public SmartMultiUpload getSmartUpload() {
@@ -57,6 +61,10 @@ public class MultiFileUpload extends CustomComponent {
         return new UploadStatePanel(uploadStateWindow);
     }
 
+    public void setAllFilesUploadedHandler(final AllFilesUploadedHandler allFilesUploadedHandler) {
+        this.getUploadStatePanel().setAllFilesUploadedHandler(allFilesUploadedHandler);
+    }
+
     private void initSmartUpload(UploadFinishedHandler handler, boolean multiple) {
         smartUpload = new SmartMultiUpload(uploadStatePanel, multiple);
 
@@ -64,6 +72,10 @@ public class MultiFileUpload extends CustomComponent {
         uploadStatePanel.setFinishedHandler(handler);
 
         setCompositionRoot(smartUpload);
+    }
+
+    public void setUploadFinishHandler(final UploadFinishedHandler uploadFinishHandler) {
+        this.uploadStatePanel.setFinishedHandler(uploadFinishHandler);
     }
 
     public void setUploadButtonCaptions(String singleUploadCaption, String multiUploadCaption) {

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStateLayout.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStateLayout.java
@@ -15,17 +15,11 @@
  */
 package com.wcs.wcslib.vaadin.widget.multifileupload.ui;
 
-import com.vaadin.ui.Alignment;
-import com.vaadin.ui.Button;
-import com.vaadin.ui.CssLayout;
-import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Label;
-import com.vaadin.ui.ProgressBar;
-import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.*;
 import com.wcs.wcslib.vaadin.widget.multifileupload.component.UploadUtil;
 
 /**
- *
+ * 
  * @author gergo
  */
 public class UploadStateLayout extends CssLayout {
@@ -92,10 +86,12 @@ public class UploadStateLayout extends CssLayout {
 
     public void setProgress(long bytesReceived, long contentLength) {
         pi.setValue(new Float(bytesReceived / (float) contentLength));
-        textualProgress.setValue(
-                UploadUtil.getHumanReadableByteCount(bytesReceived, false)
-                + " / "
-                + UploadUtil.getHumanReadableByteCount(contentLength, false));
+        if (pi.isIndeterminate()) {
+            textualProgress.setValue(UploadUtil.getHumanReadableByteCount(contentLength, false));
+        } else {
+            textualProgress.setValue(UploadUtil.getHumanReadableByteCount(bytesReceived, false) + " / "
+                    + UploadUtil.getHumanReadableByteCount(contentLength, false));
+        }
     }
 
     public void startStreaming(FileDetailBean fileDetailBean) {
@@ -113,5 +109,9 @@ public class UploadStateLayout extends CssLayout {
 
     public FileDetailBean getFileDetailBean() {
         return fileDetailBean;
+    }
+
+    public void setIndeterminate(boolean indeterminate) {
+        this.pi.setIndeterminate(indeterminate);
     }
 }

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStateLayout.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStateLayout.java
@@ -105,6 +105,7 @@ public class UploadStateLayout extends CssLayout {
         cancelLayout.replaceComponent(cancelButton, newCancelBtn);
         cancelButton = newCancelBtn;
         cancelButton.addStyleName(CANCEL_BUTTON_STYLE_CLASS);
+        textualProgress.setValue(UploadUtil.getHumanReadableByteCount(fileDetailBean.getContentLength(), false));
     }
 
     public FileDetailBean getFileDetailBean() {

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStatePanel.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStatePanel.java
@@ -208,4 +208,8 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
     public boolean hasUploadInProgress() {
         return !uploadQueue.isEmpty();
     }
+
+    public UploadStateLayout  getCurrentUploadingLayout() {
+        return this.currentUploadingLayout;
+    }
 }

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStatePanel.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStatePanel.java
@@ -19,12 +19,14 @@ import com.vaadin.server.StreamVariable;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Window;
 import com.wcs.wcslib.vaadin.widget.multifileupload.component.FileDetail;
 import com.wcs.wcslib.vaadin.widget.multifileupload.component.MultiUploadHandler;
 import com.wcs.wcslib.vaadin.widget.multifileupload.component.SmartMultiUpload;
 import com.wcs.wcslib.vaadin.widget.multifileupload.component.UploadUtil;
 import com.wcs.wcslib.vaadin.widget.multifileupload.receiver.DefaultUploadReceiver;
 import com.wcs.wcslib.vaadin.widget.multifileupload.receiver.UploadReceiver;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -34,7 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- *
+ * 
  * @author gergo
  */
 public class UploadStatePanel extends Panel implements MultiUploadHandler {
@@ -43,21 +45,32 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
     private static final String PANEL_STLYE_CLASS = "multiple-upload-state-panel";
     private List<FileDetailBean> uploadQueue = new ArrayList<>();
     private UploadStateLayout currentUploadingLayout;
-    private UploadStateWindow window;
+    private final UploadStateWindow window;
     private SmartMultiUpload multiUpload;
     private UploadReceiver receiver;
     private UploadFinishedHandler finishedHandler;
+    private AllFilesUploadedHandler allFilesUploadedHandler;
     private UploadQueueTable table = new UploadQueueTable();
+    private boolean firstStreamed = false;
 
     public UploadStatePanel(UploadStateWindow window) {
         this(window, new DefaultUploadReceiver());
     }
 
-    public UploadStatePanel(UploadStateWindow window, UploadReceiver uploadReceiver) {
+    public UploadStatePanel(final UploadStateWindow window, final UploadReceiver uploadReceiver) {
         this.window = window;
         this.receiver = uploadReceiver;
         setVisible(false);
         setStyleName(PANEL_STLYE_CLASS);
+
+        this.window.addCloseListener(new Window.CloseListener() {
+            @Override
+            public void windowClose(final Window.CloseEvent closeEvent) {
+                if (!uploadQueue.isEmpty()) {
+                    UploadStatePanel.this.window.getConfirmDialog().show();
+                }
+            }
+        });
 
         createLayout();
     }
@@ -75,11 +88,8 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
         if (event.getContentLength() > multiUpload.getMaxFileSize() || event.getContentLength() <= 0) {
             //the client side file size check may not work in old browsers
             interruptUpload(uploadQueue.get(0));
-            String formattedErrorMsg = UploadUtil.getSizeErrorMessage(
-                    multiUpload.getSizeErrorMsg(),
-                    multiUpload.getMaxFileSize(),
-                    (int) event.getContentLength(),
-                    event.getFileName());
+            String formattedErrorMsg = UploadUtil.getSizeErrorMessage(multiUpload.getSizeErrorMsg(),
+                    multiUpload.getMaxFileSize(), (int) event.getContentLength(), event.getFileName());
             Notification.show(formattedErrorMsg, Notification.Type.WARNING_MESSAGE);
             return false;
         }
@@ -90,11 +100,10 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
         if (multiUpload.getAcceptedMimeTypes() != null && !multiUpload.getAcceptedMimeTypes().isEmpty()
                 && !multiUpload.getAcceptedMimeTypes().contains(event.getMimeType())) {
             logger.log(Level.FINE, "Mime type is not valid! File name: {0}, Mime type: {1}",
-                    new Object[]{event.getFileName(), event.getMimeType()});
+                    new Object[] { event.getFileName(), event.getMimeType() });
 
             interruptUpload(uploadQueue.get(0));
-            String formattedErrorMsg = UploadUtil.getMimeTypeErrorMessage(
-                    multiUpload.getMimeTypeErrorMsgPattern(),
+            String formattedErrorMsg = UploadUtil.getMimeTypeErrorMessage(multiUpload.getMimeTypeErrorMsgPattern(),
                     event.getFileName());
             Notification.show(formattedErrorMsg, Notification.Type.WARNING_MESSAGE);
             return false;
@@ -110,18 +119,35 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
                 return;
             }
 
-            currentUploadingLayout.startStreaming(uploadQueue.get(0));
-            show();
+            if (firstStreamed) {
+                currentUploadingLayout.startStreaming(uploadQueue.get(0));
+            } else {
+                firstStreamed = true;
+            }
         }
     }
 
     @Override
     public void streamingFinished(StreamVariable.StreamingEndEvent event) {
-        removeFromQueue(currentUploadingLayout.getFileDetailBean());
-        InputStream stream = receiver.getStream();
-        //"simple" Upload fires Upload.FinishedEvent on interruptUpload()
-        if (stream != null) {
-            finishedHandler.handleFile(stream, event.getFileName(), event.getMimeType(), event.getBytesReceived());
+        try {
+            removeFromQueue(currentUploadingLayout.getFileDetailBean());
+            InputStream stream = receiver.getStream();
+            //"simple" Upload fires Upload.FinishedEvent on interruptUpload()
+            if (stream != null) {
+                if (finishedHandler != null) {
+                    finishedHandler.handleFile(stream, event.getFileName(), event.getMimeType(),
+                            event.getBytesReceived());
+                }
+
+            }
+            if (uploadQueue.isEmpty()) {
+                if (allFilesUploadedHandler != null) {
+                    allFilesUploadedHandler.uploaded();
+                }
+                window.hide();
+                window.cleanTotals();
+            }
+        } finally {
             receiver.deleteTempFile();
         }
     }
@@ -133,8 +159,8 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
 
     @Override
     public void streamingFailed(StreamVariable.StreamingErrorEvent event) {
-//        Logger.getLogger(getClass().getName()).log(Level.FINE,
-//                "Streaming failed", event.getException());
+        //        Logger.getLogger(getClass().getName()).log(Level.FINE,
+        //                "Streaming failed", event.getException());
         receiver.deleteTempFile();
     }
 
@@ -155,19 +181,25 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
         }
         table.refreshContainerDatasource(uploadQueue);
         window.setTotalContentLength(window.getTotalContentLength() + totalContentLength);
+        currentUploadingLayout.startStreaming(uploadQueue.get(0));
+        this.show();
     }
 
     private void show() {
         setVisible(true);
-        window.refreshVisibility();
+        window.show();
+    }
+
+    private void hide() {
+        setVisible(false);
+        window.hide();
     }
 
     public void removeFromQueue(FileDetailBean fileDetail) {
         uploadQueue.remove(fileDetail);
         table.refreshContainerDatasource(uploadQueue);
         if (uploadQueue.isEmpty()) {
-            setVisible(false);
-            window.refreshVisibility();
+            this.hide();
         }
     }
 
@@ -181,6 +213,10 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
 
     public void setFinishedHandler(UploadFinishedHandler finishedHandler) {
         this.finishedHandler = finishedHandler;
+    }
+
+    public void setAllFilesUploadedHandler(final AllFilesUploadedHandler allFilesUploadedHandler) {
+        this.allFilesUploadedHandler = allFilesUploadedHandler;
     }
 
     public UploadStateWindow getWindow() {
@@ -198,7 +234,8 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
         for (int i = uploadQueue.size() - 1; i >= 0; i--) {
             interruptUpload(uploadQueue.get(i));
         }
-        window.refreshVisibility();
+        window.hide();
+        window.cleanTotals();
     }
 
     public UploadQueueTable getTable() {
@@ -209,7 +246,7 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
         return !uploadQueue.isEmpty();
     }
 
-    public UploadStateLayout  getCurrentUploadingLayout() {
+    public UploadStateLayout getCurrentUploadingLayout() {
         return this.currentUploadingLayout;
     }
 }

--- a/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStateWindow.java
+++ b/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStateWindow.java
@@ -21,11 +21,12 @@ import com.vaadin.server.Resource;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
+ * 
  * @author gergo
  */
 @StyleSheet("uploadstatewindow.css")
@@ -47,15 +48,9 @@ public class UploadStateWindow extends Window {
 
     public enum WindowPosition {
 
-        BOTTOM("position-bottom"),
-        BOTTOM_LEFT("position-bottom-left"),
-        BOTTOM_RIGHT("position-bottom-right"),
-        TOP("position-top"),
-        TOP_LEFT("position-top-left"),
-        TOP_RIGHT("position-top-right"),
-        LEFT("position-left"),
-        RIGHT("position-right"),
-        CENTER("");
+        BOTTOM("position-bottom"), BOTTOM_LEFT("position-bottom-left"), BOTTOM_RIGHT("position-bottom-right"), TOP(
+                "position-top"), TOP_LEFT("position-top-left"), TOP_RIGHT("position-top-right"), LEFT("position-left"), RIGHT(
+                "position-right"), CENTER("");
         private String style;
 
         private WindowPosition(String style) {
@@ -84,13 +79,8 @@ public class UploadStateWindow extends Window {
         setWindowPosition(WindowPosition.BOTTOM_RIGHT);
         setOverallProgressVisible(true);
         setClosable(true);
-        addCloseListener(new CloseListener() {
-            @Override
-            public void windowClose(CloseEvent e) {
-                show();
-                confirmDialog.show();
-            }
-        });
+
+        confirmDialog.setPositionY(100);
 
         confirmDialog.setAction(new ConfirmAction() {
             @Override
@@ -104,34 +94,24 @@ public class UploadStateWindow extends Window {
         windowLayout.setMargin(false);
     }
 
-    public void refreshVisibility() {
-        if (hasVisibleContent()) {
-            show();
-        } else {
-            confirmDialog.hide();
-            hide();
-            setTotalContentLength(0);
-            setTotalBytesReceived(0);
-        }
+    public void cleanTotals() {
+        setTotalContentLength(0);
+        setTotalBytesReceived(0);
     }
 
-    private boolean hasVisibleContent() {
-        for (UploadStatePanel uploadStatePanel : uploadStatePanels) {
-            if (uploadStatePanel.isVisible()) {
-                return true;
+    public void show() {
+        if (this.getConfirmDialog().getParent() == null) {
+            if (this.getParent() == null) {
+                UI.getCurrent().addWindow(this);
             }
+            setVisible(true);
         }
-        return false;
     }
 
-    private void show() {
-        if (this.getParent() == null) {
-            UI.getCurrent().addWindow(this);
+    public void hide() {
+        if (this.getParent() != null) {
+            UI.getCurrent().removeWindow(this);
         }
-        setVisible(true);
-    }
-
-    private void hide() {
         setVisible(false);
     }
 
@@ -146,7 +126,7 @@ public class UploadStateWindow extends Window {
         if (overallProgressVisible) {
             int overallProgress = (int) ((totalBytesReceived * 100.0f) / totalContentLength);
             setCaption(uploadStatusCaption + " (" + overallProgress + "%)");
-        }else{
+        } else {
             setCaption(uploadStatusCaption);
         }
     }


### PR DESCRIPTION
Because of security reasons some proxies like ngnix or apache buffers data before send it to server (tomcat). In this case we don't have information about progress. In this cases would be great to have possibility to set Multifile upload component in indeterinate mode. In this mode we show only indeterminate information about uploading. Would be great to add this functionality to base component.