### PR TITLE
UploadStatePanel not hown for first file bug fix

### DIFF
--- a/vaadin-multifileupload/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStatePanel.java
+++ b/vaadin-multifileupload/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/ui/UploadStatePanel.java
@@ -112,8 +112,8 @@ public class UploadStatePanel extends Panel implements MultiUploadHandler {
             if (!isValidFileSize(event) || !isValidMimeType(event)) {
                 return;
             }
-            currentUploadingLayout.startStreaming(uploadQueue.get(0));
             show();
+            currentUploadingLayout.startStreaming(uploadQueue.get(0));
             if (startedHandler != null) {
                 startedHandler.handleUploadStarted();
             }


### PR DESCRIPTION
This commit fixes below 2 issues
If one file is uploaded UploadStatePanel does not show until the upload compeltes.
If multiple files are uploaded, then the uploadStatePanel appers after the first file is uploaded.