### PR TITLE
Fix #59

### DIFF
--- a/vaadin-multifileupload-demo/pom.xml
+++ b/vaadin-multifileupload-demo/pom.xml
@@ -20,7 +20,7 @@
         <project.build.java.version>1.8</project.build.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.vaadin>8.0.3</version.vaadin>
+        <version.vaadin>8.2.0</version.vaadin>
         <widgetset>com.wcs.wcslib.vaadin.widget.multifileupload.DemoWidgetSet</widgetset>
     </properties>
 

--- a/vaadin-multifileupload/pom.xml
+++ b/vaadin-multifileupload/pom.xml
@@ -20,7 +20,7 @@
         <project.build.java.version>1.8</project.build.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.vaadin>8.0.3</version.vaadin>
+        <version.vaadin>8.2.0</version.vaadin>
         <widgetset>com.wcs.wcslib.vaadin.widget.multifileupload.WidgetSet</widgetset>
 		
         <!-- ZIP Manifest fields -->


### PR DESCRIPTION
com.vaadin.ui.components.grid.DescriptionGenerator has been deprecated and the Grid uses com.vaadin.ui.DescriptionGenerator instead.

This breaks backwards binary compatibility (in some cases probably also source compatibility) leading to the exception in https://github.com/wbstr/vaadin-multifileupload/issues/59.

Compiling using 8.2.0 fixes this and makes the versions released from here on incompatible with versions < 8.2.0