### PR TITLE
Fix java.lang.IndexOutOfBoundsException in streamingFinished method

### DIFF
--- a/vaadin-multifileupload/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/component/MultiUpload.java
+++ b/vaadin-multifileupload/src/main/java/com/wcs/wcslib/vaadin/widget/multifileupload/component/MultiUpload.java
@@ -123,7 +123,9 @@ public class MultiUpload extends AbstractComponent implements LegacyComponent, U
                     return event.getBytesReceived();
                 }
             });
-            pendingFiles.remove(0);
+            if (!pendingFiles.isEmpty()) {
+                pendingFiles.remove(0);
+            }
         }
 
         @Override


### PR DESCRIPTION
This mostly encountered when you canceled a (last) file from the queue.